### PR TITLE
Include git SHA1 info in --version in CI/CD release builds

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build release
         id: release
         run: |
-          cargo build --release --locked
+          PROJECT_VERSION=$(git describe --dirty) cargo build --release --locked
           echo ::set-output name=BIN_PATH::./target/release/git-repo-language-trends${{ matrix.os.bin-suffix }}
       - name: Strip release build
         run: |

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,7 +300,8 @@ You can manually pass other file extensions as arguments if you want other data.
 }
 
 fn main() {
-    let args = Args::from_args();
+    let version = option_env!("PROJECT_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    let args = Args::from_clap(&Args::clap().version(version).get_matches());
     match run(&args) {
         Ok(()) => {}
         Err(e) => eprintln!("Error: {}", e),


### PR DESCRIPTION
If you also want it locally, prefix your cargo commands with
PROJECT_VERSION=$(git describe --dirty), like this:

    PROJECT_VERSION=$(git describe --dirty) cargo run -- --version