### PR TITLE
Cargo.toml: Use minimal set of git2 features

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Package release build
         id: package
         run: |
-          VERSION=$(sed -n 's/version = "\([^"]*\)"/\1/p' Cargo.toml)
+          VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml)
           TRIPLET=$(rustup show active-toolchain | sed -n 's/stable-\([^ ]*\) .*/\1/p')
           PACKAGE_NAME=git-repo-language-trends_${VERSION}_${TRIPLET}.zip
           7z a $PACKAGE_NAME ${{ steps.release.outputs.BIN_PATH }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,8 +171,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -246,24 +244,8 @@ checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df40b13fe7ea1be9b9dffa365a51273816c345fc1811478b57ed7d964fbfc4ce"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -335,25 +317,6 @@ name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.3.0"
 
 [dependencies]
 chrono = "0.4"
-git2 = "0.13"
+git2 = { version = "0.13", default-features = false }
 indicatif = "0.15"
 structopt = "0.3"
 


### PR DESCRIPTION
We only use local features, so in particular we want to get rid of
openssl deps.