### PR TITLE
tests: Make subprocess.run() call Python 3.6 compatible

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7 # for test, 3.6 for app, TODO: Solve this better
+          python-version: 3.6
       - name: Install
         run: |
           # "We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default."

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ then make your changes. When done, lint and test:
 
 
 # TODO
+* force print of last progress numbers
 * limit size of cache
-* Fix CI to use Python 3.6 for app
 * Add .tsv and .csv and .png and .svg CLI test cases
 * More examples, make image links work on pip repo too
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,8 @@ def run_git_repo_language_trends(args, env=None):
     print(" ".join(used_args) + "\n")
     result = subprocess.run(
         used_args,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=used_env,
     )
 


### PR DESCRIPTION
So that not only the program can run on Python 3.6, but also all tests.