### PR TITLE
Don't hold on to pygit2 blob objects, and make cache optional

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -49,18 +49,3 @@ jobs:
           GIT_DIR=${tmpdir} git-repo-language-trends --first-commit=${tag} -o=shallow.csv
           cat shallow.csv
           cmp shallow.csv tests/data/expected-shallow.csv
-      - name: Build release
-        id: release
-        run: |
-          PROJECT_VERSION=$(git describe --dirty) echo TODO
-      - name: Package release build
-        id: package
-        run: |
-          echo TODO
-      - name: Upload artifact
-        run: |
-          echo TODO
-      - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          echo TODO

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ then make your changes. When done, lint and test:
 
 
 # TODO
-* limit size of cache
 * watermark
 * grid
 * Add .tsv and .csv and .png and .svg CLI test cases

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ second.
 
 \*with an *Intel® Celeron® J4005 CPU @ 2.00GHz*
 
+
 # Development
 
 Clone this repo:
@@ -106,11 +107,10 @@ then make your changes. When done, lint and test:
 
 # TODO
 * limit size of cache
+* watermark
+* grid
 * Add .tsv and .csv and .png and .svg CLI test cases
 * More examples, make image links work on pip repo too
 
 # Features not yet implemeneted
-* Support import of .tsv or .csv data to support generating e.g. a PNG without re-reunning analysis
-* More short options
-* Support -o args multiple times
-* Warn before overwrite existing file
+* Support import of .tsv or .csv data to support generating e.g. a .tsv without re-reunning analysis

--- a/src/git_repo_language_trends/_internal/args.py
+++ b/src/git_repo_language_trends/_internal/args.py
@@ -162,6 +162,12 @@ def get_args():
     )
 
     advanced_group.add_argument(
+        "--no-cache",
+        action='store_true',
+        help="""[ADVANCED] do not cache how many lines are in a blob""",
+    )
+
+    advanced_group.add_argument(
         "--no-progress",
         action='store_true',
         help="""[ADVANCED] do not print progress""",

--- a/src/git_repo_language_trends/_internal/main.py
+++ b/src/git_repo_language_trends/_internal/main.py
@@ -40,10 +40,10 @@ def list_available_file_extensions(args):
 
 
 def get_outputs(args):
-    # TODO: Support multiple --output arguments
+    # It should be pretty easy to add support for having multiple
+    # outputs generated at once, but for now we only support one at a time.
     outputs = []
 
-    # TODO: CLI tests
     if args.output_ext == ".svg" or args.output_ext == ".png":
         outputs.append(MatplotlibOutput(args))
     elif args.output_ext == ".tsv":

--- a/src/git_repo_language_trends/_internal/matplotlib_output.py
+++ b/src/git_repo_language_trends/_internal/matplotlib_output.py
@@ -42,7 +42,6 @@ class MatplotlibOutput(Output):
         if self.args.style == "light":
             matplotlib_style = "default"
 
-        # TODO: Validate arg earlier
         width_inches, height_inches = self.args.size_inches.split(':')
         width_inches = float(width_inches)
         height_inches = float(height_inches)
@@ -59,6 +58,5 @@ class MatplotlibOutput(Output):
         plt.tick_params(axis='x', labelrotation=45)
         plt.tight_layout()
 
-        # TODO: Support stdout output
         plt.savefig(self.args.output)
         print_file_written(self.args.output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,6 +167,28 @@ Wrote output to file:
 """)
 
 
+def test_own_git_repo_max_commits_5_no_cache(tsv_output_path):
+    run_git_repo_language_trends_output_test(tsv_output_path, [
+        "--min-interval-days=0",
+        "--max-commits=5",
+        "--first-commit=v0.1.2",
+        "--no-cache",
+        ".yml",
+        ".rs",
+    ], """          	.yml	.rs
+2021-01-23	22	121
+2021-01-23	57	121
+2021-01-23	78	121
+2021-01-23	67	121
+2021-01-23	66	121
+""", f"""
+Wrote output to file:
+
+    {tsv_output_path}
+
+""")
+
+
 def test_own_git_repo_max_commits_0(tsv_output_path):
     run_git_repo_language_trends_output_test(tsv_output_path, [
         "-n=0",


### PR DESCRIPTION
    Don't hold on to pygit2 blob objects, and make cache optional
    
    The reason we don't want to hold on to pygit2 Blob objects is that that
    prevents the underlying git_blob_free() from being called right after we
    are doing counting lines for a blob.
    
    This is bad, since memoryview(blob) calls the libgi2
    git_blob_rawcontent(), which very quickly fills up hunder of megs of
    heap for large repos.
    
    With this refactoring, we get this as the program runs:
    
        git_blob_rawcontent()
        git_object_free() // equivalent to git_blob_free()
        git_blob_rawcontent()
        git_object_free()
        git_blob_rawcontent()
        git_object_free()
    
    instead of this
    
        git_blob_rawcontent()
        git_blob_rawcontent()
        git_blob_rawcontent()
        git_object_free()
        git_object_free()
        git_object_free()
