### PR TITLE
Become pygit2 >= 1.15.0 compatible by stop using deprecated APIs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,9 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - { name: ubuntu-18.04 }
-          - { name: macos-10.15 }
-          - { name: windows-2019 }
+          - { name: ubuntu-22.04 }
+          - { name: macos-15 }
     runs-on: ${{ matrix.os.name }}
     defaults:
       run:
@@ -26,13 +25,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
       - name: Install
         run: |
-          # "We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default."
-          pip install --use-feature=in-tree-build .
+          pip install .
       - name: Install dev dependencies
         run: |
           pip install flake8 pytest
@@ -54,8 +49,3 @@ jobs:
         run: |
           export OUTDIR=grlt-samples
           ./scripts/generate-png-and-svg-samples.sh
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
-        with:
-          name: grlt-samples-${{ matrix.os.name }}
-          path: grlt-samples

--- a/.github/workflows/PyPI-deploy.yml
+++ b/.github/workflows/PyPI-deploy.yml
@@ -14,9 +14,6 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
       - name: Install dependencies
         run: |
           pip install build twine

--- a/src/git_repo_language_trends/__init__.py
+++ b/src/git_repo_language_trends/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 def main():

--- a/src/git_repo_language_trends/_internal/main.py
+++ b/src/git_repo_language_trends/_internal/main.py
@@ -206,11 +206,11 @@ def get_blobs_in_commit(commit):
 
 
 def get_lines_in_blob(blob, blob_to_lines_cache):
-    # Don't use the blob.oid directly, because that will keep the underlying git
+    # Don't use the blob.id directly, because that will keep the underlying git
     # blob object alive, preventing freeing of the blob content from
     # git_blob_get_rawcontent(), which quickly accumulate to hundred of megs of
     # heap memory when analyzing large git projects such as the linux kernel
-    hex = blob.oid.hex
+    hex = str(blob.id)
 
     if blob_to_lines_cache is not None and hex in blob_to_lines_cache:
         return blob_to_lines_cache[hex]
@@ -235,7 +235,7 @@ def get_git_log_walker(args):
 
     rev = repo.revparse_single(args.first_commit)
 
-    walker = repo.walk(rev.peel(pygit2.Commit).oid)
+    walker = repo.walk(rev.peel(pygit2.Commit).id)
 
     if not args.all_parents:
         walker.simplify_first_parent()

--- a/src/git_repo_language_trends/_internal/progress.py
+++ b/src/git_repo_language_trends/_internal/progress.py
@@ -30,10 +30,10 @@ class Progress:
             commit_part = ""
         else:
             # "commit  12/345 "
-            commit_part = f"commit {padded_progress(self.current_commit,self.total_commits)} "
+            commit_part = f"commit {padded_progress(self.current_commit, self.total_commits)} "
 
         # "file  67/890"
-        file_part = f"file {padded_progress(current_file,total_files)}"
+        file_part = f"file {padded_progress(current_file, total_files)}"
 
         # "Counting lines in commit  12/345 file  67/890"
         print(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.fixture
 def random_output_basename(tmp_path):
-    return str(tmp_path / f"output-{randint(1,100000)}")
+    return str(tmp_path / f"output-{randint(1, 100000)}")
 
 
 @pytest.fixture


### PR DESCRIPTION
See https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md#1150-2024-05-18

Also fix some lints and remove broken stuff.